### PR TITLE
- enable only allowed_users to use the bot. applied via config file.

### DIFF
--- a/mega/common.py
+++ b/mega/common.py
@@ -1,3 +1,4 @@
+import ast
 import configparser
 import os
 
@@ -31,6 +32,9 @@ class Common:
             self.bot_session = self.app_config.get("bot-configuration", "session")
             self.bot_api_key = self.app_config.get("bot-configuration", "api_key")
             self.bot_dustbin = int(self.app_config.get("bot-configuration", "dustbin"))
+            self.allowed_users = ast.literal_eval(
+                self.app_config.get("bot-configuration", "allowed_users", fallback='[]')
+            )
 
             self.db_host = self.app_config.get("database", "db_host")
             self.db_username = self.app_config.get("database", "db_username")

--- a/mega/telegram/plugins/common.py
+++ b/mega/telegram/plugins/common.py
@@ -1,6 +1,8 @@
 from pyrogram import filters, emoji, Client
 from pyrogram.types import Message
+
 from mega.database.files import MegaFiles
+from ...telegram import Common
 
 
 @Client.on_message(filters.command("start", prefixes=["/"]))
@@ -30,3 +32,12 @@ async def start_message_handler(c: Client, m: Message):
         await m.reply_text(
             text=f"Hello! My name is Megatron {emoji.MAN_BOWING_DARK_SKIN_TONE}"
         )
+
+
+@Client.on_message(group=-1)
+async def stop_user_from_doing_anything(_, message: Message):
+    allowed_users = Common().allowed_users
+    if allowed_users and message.from_user.id not in allowed_users:
+        message.stop_propagation()
+    else:
+        message.continue_propagation()

--- a/mega/working_dir/config.ini.sample
+++ b/mega/working_dir/config.ini.sample
@@ -1,12 +1,16 @@
 [pyrogram]
 api_id = 
 api_hash = 
+
 [plugins]
 root = mega/telegram/plugins
+
 [bot-configuration]
 api_key = 
 session = megadlbot
 dustbin = -1001179151275
+allowed_users = [123123123, 321321321]
+
 [database]
 db_host = localhost
 db_username = admin


### PR DESCRIPTION
- If config missing from file, all users are able to use the bot.
- If config is set, only the specified users are able to use the bot.