### PR TITLE
- Better support for MongoDB Atlas connection string

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,9 @@
         "ALLOWED_USERS": {
             "description": "A list of users allowed to use the bot. Please enter in the format [123123123, 321321321]"
         },
+        "IS_ATLAS": {
+            "description": "Setting this to ANYTHING will make the bot use MongoDB Atlas."
+        },
         "DATABASE_DB_HOST": {
             "description": "Watch this video to understand what database is: https://youtu.be/vgzMacnI5Z8"
         },

--- a/mega/common.py
+++ b/mega/common.py
@@ -19,6 +19,7 @@ class Common:
                 os.environ.get("ALLOWED_USERS", '[]')
             )
 
+            self.is_atlas = os.environ.get('IS_ATLAS', False)
             self.db_host = os.environ.get("DATABASE_DB_HOST")
             self.db_username = os.environ.get("DATABASE_DB_USERNAME")
             self.db_password = os.environ.get("DATABASE_DB_PASSWORD")
@@ -39,6 +40,7 @@ class Common:
                 self.app_config.get("bot-configuration", "allowed_users", fallback='[]')
             )
 
+            self.is_atlas = self.app_config.getboolean('database', 'is_atlas', fallback=False)
             self.db_host = self.app_config.get("database", "db_host")
             self.db_username = self.app_config.get("database", "db_username", fallback=None)
             self.db_password = self.app_config.get("database", "db_password", fallback=None)

--- a/mega/common.py
+++ b/mega/common.py
@@ -19,7 +19,7 @@ class Common:
                 os.environ.get("ALLOWED_USERS", '[]')
             )
 
-            self.is_atlas = os.environ.get('IS_ATLAS', False)
+            self.is_atlas = os.environ.get('IS_ATLAS', None)
             self.db_host = os.environ.get("DATABASE_DB_HOST")
             self.db_username = os.environ.get("DATABASE_DB_USERNAME")
             self.db_password = os.environ.get("DATABASE_DB_PASSWORD")

--- a/mega/database/__init__.py
+++ b/mega/database/__init__.py
@@ -7,19 +7,15 @@ from mega.common import Common
 
 class MegaDB:
     def __init__(self):
-        DB_USERNAME = Common().db_username
-        DB_PASSWORD = Common().db_password
-
-        if DB_USERNAME and DB_PASSWORD:
-            connection_string = f"mongodb://{Common().db_username}:{quote(Common().db_password)}@{Common().db_host}"
+        if Common().is_atlas:
             self.db_client = pymongo.MongoClient(
-                connection_string
+                Common().db_host,
             )
         else:
             self.db_client = pymongo.MongoClient(
                 Common().db_host,
-                username=DB_USERNAME,
-                password=DB_PASSWORD
+                username=Common().db_username,
+                password=Common().db_password
             )
 
         self.db = self.db_client[Common().db_name]


### PR DESCRIPTION
- Added new config variable under the 'database' section. When using MongoDB Atlast, the database section should look like the following. 
```
[database]
is_atlas = True
db_host = mongodb+srv://<username>:<password>@something.mongodb.net/megadlbot?retryWrites=true&w=majority
db_username =
db_password =
db_name = megadlbot
```

- Heroku users now have a new environment variable called `IS_ATLAS` which, when filled, instructs the bot to use the MongoDB Atlas connection string.
- Heroku users using MongoDB Atlas do not need to fill the `db_username` and `db_password` field.
> USERS MUST URLENCODE THEIR PASSWORD ON THEIR OWN WHEN USING MongoDB Atlas