### PR TITLE
Fix 400 RESULTS_TOO_MUCH exception in inline query

### DIFF
--- a/mega/database/files.py
+++ b/mega/database/files.py
@@ -37,6 +37,6 @@ class MegaFiles:
     async def get_file_by_file_id(self, file_id: str):
         return self.files_collection.find_one({"file_id": file_id})
 
-    async def get_file_by_name(self, file_name: str):
-        return self.files_collection.find({"file_name": re.compile(file_name, re.IGNORECASE)})
+    async def get_file_by_name(self, file_name: str, row_limit: int):
+        return self.files_collection.find({"file_name": re.compile(file_name, re.IGNORECASE)}).limit(row_limit)
 

--- a/mega/telegram/plugins/file_query.py
+++ b/mega/telegram/plugins/file_query.py
@@ -8,7 +8,7 @@ from mega.database.files import MegaFiles
 @Client.on_inline_query()
 async def inline_query_handler(c: Client, iq: InlineQuery):
     q = iq.query
-    q_res_data = await MegaFiles().get_file_by_name(q)
+    q_res_data = await MegaFiles().get_file_by_name(q, 50)
     me = await c.get_me()
     res = []
     if q_res_data is not None:


### PR DESCRIPTION
This exception occurs when the database return more that 50 results to the inline query answer.